### PR TITLE
Moved endpoint version out of base_url.

### DIFF
--- a/lib/riot_api/api.rb
+++ b/lib/riot_api/api.rb
@@ -5,7 +5,7 @@ module RiotApi
       @region              = params[:region]
       @debug               = params[:debug]
       @ssl                 = params[:ssl] || { :verify => true }
-      @base_url            = params[:base_url]            || "http://prod.api.pvp.net/api/lol/#{@region}/v1.1/"
+      @base_url            = params[:base_url]            || "http://prod.api.pvp.net/api/lol/#{@region}/"
       @faraday_adapter     = params[:faraday_adapter]     || Faraday.default_adapter
       @raise_status_errors = params[:raise_status_errors] || false
       @faraday             = params[:faraday]             || default_faraday

--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -4,6 +4,10 @@ module RiotApi
       def initialize(connection, options = {})
         @connection = connection
       end
+
+      def endpoint_version
+        "v1.1"
+      end
     end
   end
 end

--- a/lib/riot_api/resource/stats.rb
+++ b/lib/riot_api/resource/stats.rb
@@ -3,13 +3,18 @@ module RiotApi
     class Stats < Base
 
       def ranked(id, opts = {})
-        @connection.get("stats/by-summoner/#{id}/ranked").body
+        @connection.get("#{base_path(id)}/ranked").body
       end
 
       def summary(id, opts = {})
-        @connection.get("stats/by-summoner/#{id}/summary").body
+        @connection.get("#{base_path(id)}/summary").body
       end
 
+      private
+
+      def base_path(id)
+        "#{endpoint_version}/stats/by-summoner/#{id}"
+      end
     end
   end
 end

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -3,11 +3,17 @@ module RiotApi
     class Summoner < Base
 
       def name(name, opts = {})
-        @connection.get("summoner/by-name/#{name}/").body
+        @connection.get("#{base_path}/by-name/#{name}/").body
       end
 
       def id(id, opts = {})
-        @connection.get("summoner/#{id}/").body
+        @connection.get("#{base_path}/#{id}/").body
+      end
+
+      private
+
+      def base_path
+        "#{endpoint_version}/summoner/"
       end
 
     end


### PR DESCRIPTION
Riot has different endpoint versions for different points.  For example,
champion is 1.1 but league is 2.1.  This allows each module to implement
their own endpoint version.

Unfortunately I should've implemented this before implementing the methods for `game` and `champions` as those will need to be modified slightly to add the version to their respective paths.

If you want to pull this in first, I'll fix my other two PRs to use the `endpoint_version`.  Then I'll write the methods for `league`.

Tests are green locally w/ this branch.
