### PR TITLE
Ignore VCR support file

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'simplecov'
 require 'coveralls'
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+  add_filter 'support/vcr'
+end
+
 Coveralls.wear!
 
 require 'rspec/autorun'


### PR DESCRIPTION
Coveralls is giving a 99% coverage because it doesn't like the fact that the VCR support file doesn't run recording in Travis CI.

This will ignore that file... I think?
