### PR TITLE
Changed how path is created to handle Riot v2.1 api path.

### DIFF
--- a/lib/riot_api/api.rb
+++ b/lib/riot_api/api.rb
@@ -45,10 +45,6 @@ module RiotApi
       RiotApi::Resource::Summoner.new(@faraday, @region)
     end
 
-    def league
-      RiotApi::Resource::League.new(@faraday, @region)
-    end
-
     def default_faraday
       Faraday.new(:url => @base_url, :ssl => @ssl) do |faraday|
         faraday.use Faraday::Response::RaiseError if @raise_status_errors

--- a/lib/riot_api/api.rb
+++ b/lib/riot_api/api.rb
@@ -20,7 +20,7 @@ module RiotApi
       @region              = params[:region]
       @debug               = params[:debug]
       @ssl                 = params[:ssl] || { :verify => true }
-      @base_url            = params[:base_url]            || "http://prod.api.pvp.net/api/lol/#{@region}/"
+      @base_url            = params[:base_url]            || "http://prod.api.pvp.net/api/"
       @faraday_adapter     = params[:faraday_adapter]     || Faraday.default_adapter
       @raise_status_errors = params[:raise_status_errors] || false
       @faraday             = params[:faraday]             || default_faraday
@@ -30,19 +30,23 @@ module RiotApi
     end
 
     def champions
-      RiotApi::Resource::Champions.new(@faraday)
+      RiotApi::Resource::Champions.new(@faraday, @region)
     end
 
     def game
-      RiotApi::Resource::Game.new(@faraday)
+      RiotApi::Resource::Game.new(@faraday, @region)
     end
 
     def stats
-      RiotApi::Resource::Stats.new(@faraday)
+      RiotApi::Resource::Stats.new(@faraday, @region)
     end
 
     def summoner
-      RiotApi::Resource::Summoner.new(@faraday)
+      RiotApi::Resource::Summoner.new(@faraday, @region)
+    end
+
+    def league
+      RiotApi::Resource::League.new(@faraday, @region)
     end
 
     def default_faraday
@@ -57,6 +61,6 @@ module RiotApi
         faraday.headers['User-Agent'] = "riot_api rubygem v#{RiotApi::VERSION}"
       end
     end
-    
+
   end
 end

--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -1,12 +1,13 @@
 module RiotApi
   module Resource
     class Base
-      def initialize(connection, options = {})
+      def initialize(connection, region, options = {})
         @connection = connection
+        @region = region
       end
 
-      def endpoint_version
-        "v1.1"
+      def endpoint_precursor
+        "lol/#{@region}/v1.1"
       end
     end
   end

--- a/lib/riot_api/resource/champions.rb
+++ b/lib/riot_api/resource/champions.rb
@@ -13,7 +13,7 @@ module RiotApi
       private
 
       def base_path
-        "#{endpoint_version}/champion"
+        "#{endpoint_precursor}/champion"
       end
     end
   end

--- a/lib/riot_api/resource/game.rb
+++ b/lib/riot_api/resource/game.rb
@@ -13,7 +13,7 @@ module RiotApi
       end
 
       def base_path(summoner_id)
-        "#{endpoint_version}/game/by-summoner/#{summoner_id}"
+        "#{endpoint_precursor}/game/by-summoner/#{summoner_id}"
       end
 
     end

--- a/lib/riot_api/resource/stats.rb
+++ b/lib/riot_api/resource/stats.rb
@@ -13,7 +13,7 @@ module RiotApi
       private
 
       def base_path(id)
-        "#{endpoint_version}/stats/by-summoner/#{id}"
+        "#{endpoint_precursor}/stats/by-summoner/#{id}"
       end
     end
   end

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -13,7 +13,7 @@ module RiotApi
       private
 
       def base_path
-        "#{endpoint_version}/summoner/"
+        "#{endpoint_precursor}/summoner/"
       end
 
     end


### PR DESCRIPTION
Addresses #10.

I'm not a huge fan of having to pass `@region` into every single resource but I can't think of another way except to pass `self` into each one and change Base's init method to something like:

```
def initialize(api, options={})
  @faraday = api.faraday
  @region = api.region
end
```

but I'm not a fan of that either.

I already implemented a BaseV2_1 class to use with the 2.1 api methods and it works so this model is viable.  Still, not a huge fan.
