### PR TITLE
Summoner with meta

### DIFF
--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -9,6 +9,23 @@ module RiotApi
       def endpoint_precursor
         "lol/#{@region}/v1.1"
       end
+
+      private
+
+      def build_model(data)
+        model_class.new data
+      end
+
+      # Returns the Model class of the same name as the Resource.
+      # The awful idea was mine but I take no credit for the implementation.
+      # Stole it from the comments here:
+      # http://infovore.org/archives/2006/08/02/getting-a-class-object-in-ruby-from-a-string-containing-that-classes-name/
+      def model_class
+        base_class = self.class.to_s.split('::').last
+        class_name = "RiotApi::Model::#{base_class}"
+        class_name.split('::').inject(Kernel) { |scope, const_name| scope.const_get(const_name) }
+      end
+
     end
   end
 end

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -3,11 +3,11 @@ module RiotApi
     class Summoner < Base
 
       def name(name, opts = {})
-        RiotApi::Model::Summoner.new @connection.get("#{base_path}/by-name/#{name}/").body
+        build_model @connection.get("#{base_path}/by-name/#{name}/").body
       end
 
       def id(id, opts = {})
-        RiotApi::Model::Summoner.new @connection.get("#{base_path}/#{id}/").body
+        build_model @connection.get("#{base_path}/#{id}/").body
       end
 
       private


### PR DESCRIPTION
This is the same as https://github.com/petems/riot_api/pull/13 except instead of having to call

`RiotApi::Model::<model_name>.new ...`

in all the Resource classes, you can just call

`build_model ...`

and the `base` class handles the rest.

See the changes to `lib/riot_api/resource/base.rb` for the big difference.  Or just compare #13 to this.

Again, no tests yet.
