### PR TITLE
Added Summoner#names api call.

### DIFF
--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -10,6 +10,13 @@ module RiotApi
         RiotApi::Model::Summoner.new @connection.get("#{base_path}/#{id}/").body
       end
 
+      def names(*ids)
+        ids = ids.compact.join(',')
+        @connection.get("#{base_path}/#{ids}/name").body.summoners.map do |summoner|
+          RiotApi::Model::Summoner.new summoner
+        end
+      end
+
       private
 
       def base_path

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -59,6 +59,20 @@ describe RiotApi::API, :vcr do
       end
     end
 
+    describe '#names' do
+      let(:froggen) { '19531813' }
+      let(:response) {
+        subject.summoner.names summoner_id, froggen
+      }
+
+      it "should return an array of summoners with name set" do
+        response.class.should == Array
+        response.count.should == 2
+        response.first.class.should == RiotApi::Model::Summoner
+        response.first.name.should == "Best Lux EUW"
+      end
+    end
+
   end
 
   describe '#stats' do

--- a/spec/vcr/cassettes/RiotApi_API/_summoner/_names/should_return_an_array_of_summoners_with_name_set.yml
+++ b/spec/vcr/cassettes/RiotApi_API/_summoner/_names/should_return_an_array_of_summoners_with_name_set.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://prod.api.pvp.net/api/lol/euw/v1.1/summoner/44600324,19531813/name?api_key=api_key_YYYYYYYYYYYYYYYYYYYYY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - riot_api rubygem v0.0.2
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      access-control-allow-headers:
+      - Content-Type
+      access-control-allow-methods:
+      - GET, POST, DELETE, PUT
+      access-control-allow-origin:
+      - ! '*'
+      content-type:
+      - application/json;charset=UTF-8
+      date:
+      - Fri, 13 Dec 2013 14:51:17 GMT
+      server:
+      - Jetty(9.1.0.v20131115)
+      x-newrelic-app-data:
+      - XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      content-length:
+      - '86'
+      connection:
+      - Close
+    body:
+      encoding: US-ASCII
+      string: ! '{"summoners":[{"id":44600324,"name":"Best Lux EUW"},{"id":19531813,"name":"Froggen"}]}'
+    http_version: 
+  recorded_at: Fri, 13 Dec 2013 14:51:17 GMT
+recorded_with: VCR 2.8.0


### PR DESCRIPTION
I need to post on Riot's boards that this method seems pointless.  All it returns are the summoner names.  If you want more info you'll have to make a second call using "by name".  And let's say you want more info for _all_ the summoners you're searching now you're talking about N+1 API calls.  Stupid.

Anyway, this is done.  Tests are green.
