### PR TITLE
Refactor resources

### DIFF
--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -6,6 +6,10 @@ module RiotApi
         @region = region
       end
 
+      def get(path, options={})
+        @connection.get(path, options)
+      end
+
       def endpoint_precursor
         "lol/#{@region}/v1.1"
       end

--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -7,7 +7,13 @@ module RiotApi
       end
 
       def get(path, options={})
-        @connection.get(path, options).body
+        @connection.get(full_path(path), options).body
+      end
+
+      private
+
+      def full_path(path)
+        "#{endpoint_precursor}/#{path}"
       end
 
       def endpoint_precursor

--- a/lib/riot_api/resource/base.rb
+++ b/lib/riot_api/resource/base.rb
@@ -7,7 +7,7 @@ module RiotApi
       end
 
       def get(path, options={})
-        @connection.get(path, options)
+        @connection.get(path, options).body
       end
 
       def endpoint_precursor

--- a/lib/riot_api/resource/champions.rb
+++ b/lib/riot_api/resource/champions.rb
@@ -15,7 +15,7 @@ module RiotApi
       private
 
       def base_path
-        "#{endpoint_precursor}/champion"
+        "champion"
       end
     end
   end

--- a/lib/riot_api/resource/champions.rb
+++ b/lib/riot_api/resource/champions.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Champions < Base
 
       def list(free=false)
-        @connection.get(base_path, { :freeToPlay => free }).body.champions.map do |champion|
+        get(base_path, { :freeToPlay => free }).body.champions.map do |champion|
           RiotApi::Model::Champion.new(champion)
         end
       end

--- a/lib/riot_api/resource/champions.rb
+++ b/lib/riot_api/resource/champions.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Champions < Base
 
       def list(free=false)
-        get(base_path, { :freeToPlay => free }).body.champions.map do |champion|
+        get(base_path, { :freeToPlay => free }).champions.map do |champion|
           RiotApi::Model::Champion.new(champion)
         end
       end

--- a/lib/riot_api/resource/game.rb
+++ b/lib/riot_api/resource/game.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Game < Base
 
       def recent(summoner_id)
-        @connection.get(recent_path(summoner_id)).body.games
+        get(recent_path(summoner_id)).body.games
       end
 
       private

--- a/lib/riot_api/resource/game.rb
+++ b/lib/riot_api/resource/game.rb
@@ -13,7 +13,7 @@ module RiotApi
       end
 
       def base_path(summoner_id)
-        "#{endpoint_precursor}/game/by-summoner/#{summoner_id}"
+        "game/by-summoner/#{summoner_id}"
       end
 
     end

--- a/lib/riot_api/resource/game.rb
+++ b/lib/riot_api/resource/game.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Game < Base
 
       def recent(summoner_id)
-        get(recent_path(summoner_id)).body.games
+        get(recent_path(summoner_id)).games
       end
 
       private

--- a/lib/riot_api/resource/league.rb
+++ b/lib/riot_api/resource/league.rb
@@ -3,7 +3,7 @@ module RiotApi
     class League < BaseV21
 
       def by_summoner(summoner_id)
-        get(by_summoner_path(summoner_id)).body[summoner_id.to_s]
+        get(by_summoner_path(summoner_id))[summoner_id.to_s]
       end
 
       private

--- a/lib/riot_api/resource/league.rb
+++ b/lib/riot_api/resource/league.rb
@@ -13,7 +13,7 @@ module RiotApi
       end
 
       def base_path
-        "#{endpoint_precursor}/league"
+        "league"
       end
 
     end

--- a/lib/riot_api/resource/league.rb
+++ b/lib/riot_api/resource/league.rb
@@ -3,7 +3,7 @@ module RiotApi
     class League < BaseV21
 
       def by_summoner(summoner_id)
-        @connection.get(by_summoner_path(summoner_id)).body[summoner_id.to_s]
+        get(by_summoner_path(summoner_id)).body[summoner_id.to_s]
       end
 
       private

--- a/lib/riot_api/resource/stats.rb
+++ b/lib/riot_api/resource/stats.rb
@@ -13,7 +13,7 @@ module RiotApi
       private
 
       def base_path(id)
-        "#{endpoint_precursor}/stats/by-summoner/#{id}"
+        "stats/by-summoner/#{id}"
       end
     end
   end

--- a/lib/riot_api/resource/stats.rb
+++ b/lib/riot_api/resource/stats.rb
@@ -3,11 +3,11 @@ module RiotApi
     class Stats < Base
 
       def ranked(id, opts = {})
-        get("#{base_path(id)}/ranked", opts).body
+        get("#{base_path(id)}/ranked", opts)
       end
 
       def summary(id, opts = {})
-        get("#{base_path(id)}/summary", opts).body
+        get("#{base_path(id)}/summary", opts)
       end
 
       private

--- a/lib/riot_api/resource/stats.rb
+++ b/lib/riot_api/resource/stats.rb
@@ -3,11 +3,11 @@ module RiotApi
     class Stats < Base
 
       def ranked(id, opts = {})
-        @connection.get("#{base_path(id)}/ranked", opts).body
+        get("#{base_path(id)}/ranked", opts).body
       end
 
       def summary(id, opts = {})
-        @connection.get("#{base_path(id)}/summary", opts).body
+        get("#{base_path(id)}/summary", opts).body
       end
 
       private

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -28,7 +28,7 @@ module RiotApi
       private
 
       def base_path
-        "#{endpoint_precursor}/summoner/"
+        "summoner"
       end
 
     end

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -3,26 +3,26 @@ module RiotApi
     class Summoner < Base
 
       def name(name, opts = {})
-        RiotApi::Model::Summoner.new @connection.get("#{base_path}/by-name/#{name}/").body
+        RiotApi::Model::Summoner.new get("#{base_path}/by-name/#{name}/").body
       end
 
       def id(id, opts = {})
-        RiotApi::Model::Summoner.new @connection.get("#{base_path}/#{id}/").body
+        RiotApi::Model::Summoner.new get("#{base_path}/#{id}/").body
       end
 
       def masteries(id)
-        @connection.get("#{base_path}/#{id}/masteries").body
+        get("#{base_path}/#{id}/masteries").body
       end
 
       def names(*ids)
         ids = ids.compact.join(',')
-        @connection.get("#{base_path}/#{ids}/name").body.summoners.map do |summoner|
+        get("#{base_path}/#{ids}/name").body.summoners.map do |summoner|
           RiotApi::Model::Summoner.new summoner
         end
       end
 
       def runes(id)
-        @connection.get("#{base_path}/#{id}/runes").body
+        get("#{base_path}/#{id}/runes").body
       end
 
       private

--- a/lib/riot_api/resource/summoner.rb
+++ b/lib/riot_api/resource/summoner.rb
@@ -3,26 +3,26 @@ module RiotApi
     class Summoner < Base
 
       def name(name, opts = {})
-        RiotApi::Model::Summoner.new get("#{base_path}/by-name/#{name}/").body
+        RiotApi::Model::Summoner.new get("#{base_path}/by-name/#{name}/")
       end
 
       def id(id, opts = {})
-        RiotApi::Model::Summoner.new get("#{base_path}/#{id}/").body
+        RiotApi::Model::Summoner.new get("#{base_path}/#{id}/")
       end
 
       def masteries(id)
-        get("#{base_path}/#{id}/masteries").body
+        get("#{base_path}/#{id}/masteries")
       end
 
       def names(*ids)
         ids = ids.compact.join(',')
-        get("#{base_path}/#{ids}/name").body.summoners.map do |summoner|
+        get("#{base_path}/#{ids}/name").summoners.map do |summoner|
           RiotApi::Model::Summoner.new summoner
         end
       end
 
       def runes(id)
-        get("#{base_path}/#{id}/runes").body
+        get("#{base_path}/#{id}/runes")
       end
 
       private

--- a/lib/riot_api/resource/team.rb
+++ b/lib/riot_api/resource/team.rb
@@ -13,7 +13,7 @@ module RiotApi
       end
 
       def base_path
-        "#{endpoint_precursor}/team"
+        "team"
       end
 
     end

--- a/lib/riot_api/resource/team.rb
+++ b/lib/riot_api/resource/team.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Team < BaseV21
 
       def by_summoner(summoner_id)
-        @connection.get(by_summoner_path(summoner_id)).body
+        get(by_summoner_path(summoner_id)).body
       end
 
       private

--- a/lib/riot_api/resource/team.rb
+++ b/lib/riot_api/resource/team.rb
@@ -3,7 +3,7 @@ module RiotApi
     class Team < BaseV21
 
       def by_summoner(summoner_id)
-        get(by_summoner_path(summoner_id)).body
+        get(by_summoner_path(summoner_id))
       end
 
       private


### PR DESCRIPTION
I loves me some refactoring.

Now, unless Riot implements some special case (knock on wood), calls to `endpoint_precursor`, `@connection.` and `.body` should stay in `Base`.
